### PR TITLE
Fixes issue when stderr output is included in backup file name, e.g. …

### DIFF
--- a/zabbix-mysql-dump
+++ b/zabbix-mysql-dump
@@ -255,7 +255,7 @@ DB_TABLE_NUM=$(echo "$DB_TABLES" | wc -l)
 
 # Query Zabbix database version
 VERSION=""
-DB_VER=$(mysql "${MYSQL_OPTS_BATCH[@]}" -N -e "select optional from dbversion;" 2>&1)
+DB_VER=$(mysql "${MYSQL_OPTS_BATCH[@]}" -N -e "select optional from dbversion;" 2>/dev/null)
 if [ $? -eq 0 ]; then
 	# version string is like: 02030015
 	re='(.*)([0-9]{2})([0-9]{4})'


### PR DESCRIPTION
…if you specify password in the cli, you'll have

"zabbix_cfg_localhost_20160323-1758_db-Warning: Using a password on the command line interface can be insecure.?2.4.0.sql.gz"