### PR TITLE
FIX warning: here-document at line 206 delimited by end-of-file 

### DIFF
--- a/zabbix-mysql-dump
+++ b/zabbix-mysql-dump
@@ -210,7 +210,7 @@ if [ "$QUIET" == "no" ]; then
 	 - user:     $DBUSER
 	 - output:   $DUMPDIR
 
-	EOF
+EOF
 fi
 
 #


### PR DESCRIPTION
Fixing the following for zabbix 3.0.3
FIX warning: here-document at line 206 delimited by end-of-file (wanted `EOF')
/usr/local/bin/zabbix-mysql-dump: line 476: warning: here-document at line 206 delimited by end-of-file (wanted `EOF')
/usr/local/bin/zabbix-mysql-dump: line 477: syntax error: unexpected end of file
