### PR TITLE
Support MySQL Socket and loading of server config

### DIFF
--- a/zabbix-mysql-dump
+++ b/zabbix-mysql-dump
@@ -203,7 +203,7 @@ ERRORLOG=$(mktemp)
 DBHOSTNAME="$DBHOST"
 command -v dig >/dev/null 2>&1
 FIND_DIG=$?
-if [ "$REVERSELOOKUP" == "yes" -a $FIND_DIG -eq 0 -a -z "$DBHOST" ]; then
+if [ "$REVERSELOOKUP" == "yes" -a $FIND_DIG -eq 0 -a ! -z "$DBHOST" ]; then
 	# Try resolving a given host ip
 	newHostname=$(dig +noall +answer -x $DBHOST | sed -r 's/((\S+)\s+)+([^\.]+)\..*/\3/')
 	test \! -z "$newHostname" && DBHOSTNAME="$newHostname"

--- a/zabbix-mysql-dump
+++ b/zabbix-mysql-dump
@@ -156,14 +156,14 @@ if [[ -f ${ZBXCONFIG} && -r ${ZBXCONFIG} ]]; then
 fi
 
 [ ! -z "$ODBHOST" ] && DBHOST=$ODBHOST
-[ ! -z "$ODSOCKET" ] && DBHOST=$ODBSOCKET
-[ ! -z "$ODBNAME" ] && DBHOST=$ODBNAME
-[ ! -z "$ODBUSER" ] && DBHOST=$ODBUSER
-[ ! -z "$ODBPASS" ] && DBHOST=$ODBPASS
+[ ! -z "$ODBSOCKET" ] && DBSOCKET=$ODBSOCKET
+[ ! -z "$ODBNAME" ] && DBNAME=$ODBNAME
+[ ! -z "$ODBUSER" ] && DBUSER=$ODBUSER
+[ ! -z "$ODBPASS" ] && DBPASS=$ODBPASS
 
 # Password prompt
 if [ "$DBPASS" = "-" ]; then
-	read -s -p "Enter MySQL password for user '$DBUSER' (input will be hidden): " DBPASS
+	read -r -s -p "Enter MySQL password for user '$DBUSER' (input will be hidden): " DBPASS
 	echo ""
 fi
 
@@ -203,9 +203,9 @@ ERRORLOG=$(mktemp)
 DBHOSTNAME="$DBHOST"
 command -v dig >/dev/null 2>&1
 FIND_DIG=$?
-if [ "$REVERSELOOKUP" == "yes" -a $FIND_DIG -eq 0 -a ! -z "$DBHOST" ]; then
+if [ "$REVERSELOOKUP" == "yes" ] && [ $FIND_DIG -eq 0 ] && [ ! -z "$DBHOST" ]; then
 	# Try resolving a given host ip
-	newHostname=$(dig +noall +answer -x $DBHOST | sed -r 's/((\S+)\s+)+([^\.]+)\..*/\3/')
+	newHostname=$(dig +noall +answer -x "${DBHOST}" | sed -r 's/((\S+)\s+)+([^\.]+)\..*/\3/')
 	test \! -z "$newHostname" && DBHOSTNAME="$newHostname"
 fi
 
@@ -248,11 +248,11 @@ fi
 # (http://stackoverflow.com/a/3477269/2983301)
 #
 DATA_TABLES=()
-while read line; do
+while read -r line; do
 	table=$(echo "$line" | cut -d" " -f1)
 	echo "$line" | cut -d" " -f5 | grep -qi "DATA"
 	test $? -eq 0 && DATA_TABLES+=($table)
-done < <(sed '0,/^__DATA__$/d' "$BASH_SOURCE" | tr -s " ")
+done < <(sed '0,/^__DATA__$/d' "${BASH_SOURCE[*]}" | tr -s " ")
 
 # paranoid check
 if [ ${#DATA_TABLES[@]} -lt 5 ]; then
@@ -273,7 +273,8 @@ DB_TABLE_NUM=$(echo "$DB_TABLES" | wc -l)
 # Query Zabbix database version
 VERSION=""
 DB_VER=$(mysql "${MYSQL_OPTS_BATCH[@]}" -N -e "select optional from dbversion;" 2>/dev/null)
-if [ $? -eq 0 ]; then
+retval=$?
+if [ $retval -eq 0 ]; then
 	# version string is like: 02030015
 	re='(.*)([0-9]{2})([0-9]{4})'
 	if [[ $DB_VER =~ $re ]]; then

--- a/zabbix-mysql-dump
+++ b/zabbix-mysql-dump
@@ -49,6 +49,7 @@ COMPRESSION="gz"
 QUIET="no"
 REVERSELOOKUP="yes"
 GENERATIONSTOKEEP=0
+ZBXCONFIG="/etc/zabbix/zabbix_server.conf"
 
 #
 # SHOW HELP
@@ -98,6 +99,9 @@ OPTIONS
 		but the resulting backup will be about half the size of the same
 		sql file compressed using gz. Your mileage may vary.
 
+	-z
+		Specify a zabbix configuration file to read from.
+
 	-0
 		Do not compress the sql dump
 
@@ -112,6 +116,7 @@ EXAMPLES
 	$(basename $BASH_SOURCE) -u zabbix -p - -o /tmp
 	$(basename $BASH_SOURCE) -c /etc/mysql/mysql.cnf
 	$(basename $BASH_SOURCE) -c /etc/mysql/mysql.cnf -d zabbixdb
+	$(basename $BASH_SOURCE) -z /opt/etc/zabbix_server.conf -o /tmp
 
 EOF
 	exit 1
@@ -124,11 +129,13 @@ DB_GIVEN=0
 while getopts ":h:d:u:p:o:r:c:x0qn" opt; do
 	case $opt in
 		h)  DBHOST="$OPTARG" ;;
+		s)  DBSOCKET="$OPTARG" ;;
 		d)  DBNAME="$OPTARG"; DB_GIVEN=1 ;;
 		u)  DBUSER="$OPTARG" ;;
 		p)  DBPASS="$OPTARG" ;;
 		c)  CNFFILE="$OPTARG" ;;
 		o)  DUMPDIR="$OPTARG" ;;
+		z)  ZBXCONFIG="$OPTARG" ;;
 		r)  GENERATIONSTOKEEP=$(printf '%.0f' "$OPTARG") ;;
 		x)  COMPRESSION="xz" ;;
 		0)  COMPRESSION="" ;;
@@ -138,6 +145,15 @@ while getopts ":h:d:u:p:o:r:c:x0qn" opt; do
 		:)  echo "Option -$OPTARG requires an argument" >&2; exit 1 ;;
 	esac
 done
+
+if [[ -f ${ZBXCONFIG} && -r ${ZBXCONFIG} ]]; then
+	source ${ZBXCONFIG}
+	DBHOST=$DBHost
+	DBSOCKET=$DBSocket
+	DBNAME=$DBName
+	DBUSER=$DBUser
+	DBPASS=$DBPassword
+fi
 
 # Password prompt
 if [ "$DBPASS" = "-" ]; then
@@ -167,6 +183,7 @@ SUFFIX=""; test ! -z $COMPRESSION && SUFFIX=".${COMPRESSION}"
 MYSQL_OPTS=()
 [ ! -z "$CNFFILE" ] && MYSQL_OPTS=("${MYSQL_OPTS[@]}" --defaults-extra-file="$CNFFILE")
 [ ! -z "$DBHOST" ] && MYSQL_OPTS=("${MYSQL_OPTS[@]}" -h $DBHOST)
+[ ! -z "$DBSOCKET" ] && MYSQL_OPTS=("${MYSQL_OPTS[@]}" -S $DBSOCKET)
 [ ! -z "$DBUSER" ] && MYSQL_OPTS=("${MYSQL_OPTS[@]}" -u $DBUSER)
 [ ! -z "$DBPASS" ] && MYSQL_OPTS=("${MYSQL_OPTS[@]}" -p"$DBPASS")
 

--- a/zabbix-mysql-dump
+++ b/zabbix-mysql-dump
@@ -57,7 +57,7 @@ ZBXCONFIG="/etc/zabbix/zabbix_server.conf"
 if [ -z "$1" ]; then
 	cat <<EOF
 USAGE
-	$(basename $BASH_SOURCE) [options]
+	$(basename "${BASH_SOURCE[*]}") [options]
 
 OPTIONS
 	-h HOST
@@ -112,11 +112,11 @@ OPTIONS
 		Quiet mode: no output except for errors (for batch/crontab use).
 
 EXAMPLES
-	$(basename $BASH_SOURCE) -h 1.2.3.4 -d zabbixdb -u zabbix -p test
-	$(basename $BASH_SOURCE) -u zabbix -p - -o /tmp
-	$(basename $BASH_SOURCE) -c /etc/mysql/mysql.cnf
-	$(basename $BASH_SOURCE) -c /etc/mysql/mysql.cnf -d zabbixdb
-	$(basename $BASH_SOURCE) -z /opt/etc/zabbix_server.conf -o /tmp
+	$(basename "${BASH_SOURCE[*]}") -h 1.2.3.4 -d zabbixdb -u zabbix -p test
+	$(basename "${BASH_SOURCE[*]}") -u zabbix -p - -o /tmp
+	$(basename "${BASH_SOURCE[*]}") -c /etc/mysql/mysql.cnf
+	$(basename "${BASH_SOURCE[*]}") -c /etc/mysql/mysql.cnf -d zabbixdb
+	$(basename "${BASH_SOURCE[*]}") -z /opt/etc/zabbix_server.conf -o /tmp
 
 EOF
 	exit 1
@@ -148,11 +148,11 @@ done
 
 if [[ -f ${ZBXCONFIG} && -r ${ZBXCONFIG} ]]; then
 	source ${ZBXCONFIG}
-	DBHOST=$DBHost
-	DBSOCKET=$DBSocket
-	DBNAME=$DBName
-	DBUSER=$DBUser
-	DBPASS=$DBPassword
+	DBHOST="${DBHost}"
+	DBSOCKET="${DBSocket}"
+	DBNAME="${DBName}"
+	DBUSER="${DBUser}"
+	DBPASS="${DBPassword}"
 fi
 
 [ ! -z "$ODBHOST" ] && DBHOST=$ODBHOST

--- a/zabbix-mysql-dump
+++ b/zabbix-mysql-dump
@@ -126,13 +126,13 @@ fi
 # PARSE COMMAND LINE ARGUMENTS
 #
 DB_GIVEN=0
-while getopts ":h:d:u:p:o:r:c:x0qn" opt; do
+while getopts ":h:d:u:z:s:p:o:r:c:x0qn" opt; do
 	case $opt in
-		h)  DBHOST="$OPTARG" ;;
-		s)  DBSOCKET="$OPTARG" ;;
-		d)  DBNAME="$OPTARG"; DB_GIVEN=1 ;;
-		u)  DBUSER="$OPTARG" ;;
-		p)  DBPASS="$OPTARG" ;;
+		h)  ODBHOST="$OPTARG" ;;
+		s)  ODBSOCKET="$OPTARG" ;;
+		d)  ODBNAME="$OPTARG"; DB_GIVEN=1 ;;
+		u)  ODBUSER="$OPTARG" ;;
+		p)  ODBPASS="$OPTARG" ;;
 		c)  CNFFILE="$OPTARG" ;;
 		o)  DUMPDIR="$OPTARG" ;;
 		z)  ZBXCONFIG="$OPTARG" ;;
@@ -154,6 +154,12 @@ if [[ -f ${ZBXCONFIG} && -r ${ZBXCONFIG} ]]; then
 	DBUSER=$DBUser
 	DBPASS=$DBPassword
 fi
+
+[ ! -z "$ODBHOST" ] && DBHOST=$ODBHOST
+[ ! -z "$ODSOCKET" ] && DBHOST=$ODBSOCKET
+[ ! -z "$ODBNAME" ] && DBHOST=$ODBNAME
+[ ! -z "$ODBUSER" ] && DBHOST=$ODBUSER
+[ ! -z "$ODBPASS" ] && DBHOST=$ODBPASS
 
 # Password prompt
 if [ "$DBPASS" = "-" ]; then
@@ -197,7 +203,7 @@ ERRORLOG=$(mktemp)
 DBHOSTNAME="$DBHOST"
 command -v dig >/dev/null 2>&1
 FIND_DIG=$?
-if [ "$REVERSELOOKUP" == "yes" -a $FIND_DIG -eq 0 ]; then
+if [ "$REVERSELOOKUP" == "yes" -a $FIND_DIG -eq 0 -a -z "$DBHOST" ]; then
 	# Try resolving a given host ip
 	newHostname=$(dig +noall +answer -x $DBHOST | sed -r 's/((\S+)\s+)+([^\.]+)\..*/\3/')
 	test \! -z "$newHostname" && DBHOSTNAME="$newHostname"


### PR DESCRIPTION
I've changed the script to default to loading the server configuration file as it will have all the defaults in it to access the database.

This can be overridden with command line options and the defaults still exist, and would be used when the config file doesn't exist.

You can also specify -z to override the zabbix server config file location.

I also added support for DB socket.

This work showed up a bug in the do dig logic, which I've also corrected.