### PR TITLE
locate mysqldump instead of hard coding path

### DIFF
--- a/zabbix-mysql-dump
+++ b/zabbix-mysql-dump
@@ -214,7 +214,7 @@ elementIn () {
 #
 # CHECKS
 #
-if [ ! -x `which mysqldump` ]; then
+if [ ! -x $(which mysqldump) ]; then
 	echo "mysqldump not found." >&2
 	echo "(with Debian, \"apt-get install mysql-client\" will help)" >&2
 	exit 1

--- a/zabbix-mysql-dump
+++ b/zabbix-mysql-dump
@@ -214,7 +214,7 @@ elementIn () {
 #
 # CHECKS
 #
-if [ ! -x /usr/bin/mysqldump ]; then
+if [ ! -x `which mysqldump` ]; then
 	echo "mysqldump not found." >&2
 	echo "(with Debian, \"apt-get install mysql-client\" will help)" >&2
 	exit 1


### PR DESCRIPTION
The default path for mysqldump is /usr/local/bin in FreeBSD. Locating the path makes the script more compatible.