### PR TITLE
missing $DBHOST to mysql client 

### DIFF
--- a/zabbix-dump
+++ b/zabbix-dump
@@ -278,6 +278,7 @@ case $DBTYPE in
     mysql)
         [ ! -z "$MYSQL_CONFIG" ] && DB_OPTS=("${DB_OPTS[@]}" --defaults-extra-file="$MYSQL_CONFIG")
         [ ! -z "$DBSOCKET" ] && DB_OPTS=("${DB_OPTS[@]}" -S $DBSOCKET)
+        [ ! -z "$DBHOST" ] && DB_OPTS=("${DB_OPTS[@]}" -h $DBHOST)
         [ ! -z "$DBUSER" ] && DB_OPTS=("${DB_OPTS[@]}" -u $DBUSER)
         [ ! -z "$DBPASS" ] && DB_OPTS=("${DB_OPTS[@]}" -p"$DBPASS")
         DB_OPTS=("${DB_OPTS[@]}" -P"$DBPORT")

--- a/zabbix-dump
+++ b/zabbix-dump
@@ -287,6 +287,7 @@ case $DBTYPE in
         ;;
     psql)
         [ ! -z "$DBSOCKET" ] && DB_OPTS=("${DB_OPTS[@]}" -h $DBSOCKET)
+        [ ! -z "$DBHOST" ] && DB_OPTS=("${DB_OPTS[@]}" -h $DBHOST)
         [ ! -z "$DBUSER" ] && DB_OPTS=("${DB_OPTS[@]}" -U $DBUSER)
         DB_OPTS=("${DB_OPTS[@]}" -p"$DBPORT")
         if [ ! -z "$DBPASS" ]; then
@@ -298,7 +299,6 @@ case $DBTYPE in
         [ ! -z "$DBNAME" ] && DB_OPTS_BATCH=("${DB_OPTS_BATCH[@]}" -d $DBNAME)
         ;;
 esac
-[ ! -z "$DBHOST" ] && DB_OPTS=("${DB_OPTS[@]}" -h $DBHOST)
 
 # Log file for errors
 ERRORLOG=$(mktemp)


### PR DESCRIPTION
Hello guys!

- before:

```
$ ./zabbix-dump -H zabbix-db1
Configuration:
 - type:     mysql
 - host:     zabbix-db1 (zabbix-db1)
 - port:     3306
 - database: zabbix
 - user:     zabbix
 - output:   /home/tiago.cruz/movile/zabbix-backup
Fetching list of existing tables...
ERROR while trying to access database:
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2 "No such file or directory")
```

- after:

```
$ ./zabbix-dump -H zabbix-db1
Configuration:
 - type:     mysql
 - host:     zabbix-db1 (zabbix-db1)
 - port:     3306
 - database: zabbix
 - user:     zabbix
 - output:   /home/tiago.cruz/movile/zabbix-backup
Fetching list of existing tables...
ERROR while trying to access database:
ERROR 1045 (28000): Access denied for user 'zabbix'@'10.255.2.48' (using password: NO)
```

The variable `$DBHOST"` was only used um `pgsql` client, not in `mysql` 

Thanks