### PR TITLE
escape special characters while reading password

### DIFF
--- a/zabbix-dump
+++ b/zabbix-dump
@@ -216,11 +216,13 @@ if [[ "${READ_ZBX_CONFIG}" == "yes" && -f "${ZBX_CONFIG}" && -r "${ZBX_CONFIG}" 
         DBHOST="${DBHost}"
         DBSOCKET="${DBSocket}"
     fi
-
+    
     DBPORT="${DBPort}"
     DBNAME="${DBName}"
     DBUSER="${DBUser}"
-    DBPASS="${DBPassword}"
+    # Rereading password with awk, to avoid shell special characters execution.
+    DBPASS="`/usr/bin/awk -F'=' '/^DBPassword/{ print $2 }' "${ZBX_CONFIG}"`"
+
 # Otherwise: set default values
 else
     # if a MySQL config file is specified we assume it contains all connection parameters


### PR DESCRIPTION
While reading from "${ZBX_CONFIG}", `DBPassword` can contain special characters, which are interpreted by the source command.

Sourcing the (php) configuration file, in such situation can lead to backup failure.