### PR TITLE
add psql option no-psqlrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /.project
-.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.project
+.git

--- a/zabbix-dump
+++ b/zabbix-dump
@@ -438,7 +438,7 @@ case $DBTYPE in
         DB_TABLES=$(mysql "${DB_OPTS_BATCH[@]}" -e "SELECT table_name FROM information_schema.tables WHERE table_schema = '$DBNAME'" 2>$ERRORLOG)
         ;;
     psql)
-        DB_TABLES=$(psql "${DB_OPTS_BATCH[@]}" -c "SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_catalog='$DBNAME' AND table_type='BASE TABLE'" 2>$ERRORLOG)
+        DB_TABLES=$(psql --no-psqlrc "${DB_OPTS_BATCH[@]}" -c "SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_catalog='$DBNAME' AND table_type='BASE TABLE'" 2>$ERRORLOG)
         ;;
 esac
 if [ $? -ne 0 ]; then
@@ -480,7 +480,7 @@ case $DBTYPE in
         DB_VER=$(mysql "${DB_OPTS_BATCH[@]}" -N -e "select optional from dbversion;" 2>/dev/null)
         ;;
     psql)
-        DB_VER=$(psql "${DB_OPTS_BATCH[@]}" -c "select optional from dbversion;" 2>/dev/null)
+        DB_VER=$(psql --no-psqlrc "${DB_OPTS_BATCH[@]}" -c "select optional from dbversion;" 2>/dev/null)
         ;;
 esac
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
Hello.
Thanks for your script.

I have custom command in ~/.psqlrc file.
When i run zabbix-dump script I receive error.

```
Starting table backups...
./zabbix-dump: line 555: /var/lib/pgsql/11/backups/zabbix_cfg_host_20200731-0752_db-psql-Expanded display is off.
Output format is wrapped.
Timing is on.
```
and
```
  4.4.2.sql: File name too long

ERROR: Could not backup database.
```
Please, add options "--no-psqlrc" for psql command.

--no-psqlrc  Do not read the start-up file (neither the system-wide psqlrc file nor the user's ~/.psqlrc file)