### PR TITLE
Be more specific on detecting mysql socket

### DIFF
--- a/zabbix-dump
+++ b/zabbix-dump
@@ -242,9 +242,9 @@ if [[ "${READ_ZBX_CONFIG}" == "yes" && -f "${ZBX_CONFIG}" && -r "${ZBX_CONFIG}" 
     # > If set to localhost, socket is used for MySQL.
     # > If set to empty string, socket is used for PostgreSQL.
     if [[ ( "$DBTYPE" == "mysql" && "$DBHOST" == "localhost" ) || ( "$DBTYPE" == "psql" && "$DBHOST" == "" ) ]]; then
-        [ "$DBTYPE" == "mysql" ] && searchstr="mysql"
+        [ "$DBTYPE" == "mysql" ] && searchstr="mysqld.sock"
         [ "$DBTYPE" == "psql" ] && searchstr="postgres"
-        sock=$(netstat -axn | grep -m1 "$searchstr" | sed -r 's/^.*\s+([^ ]+)$/\1/')
+        sock=$(netstat -lxn | grep -m1 "$searchstr" | sed -r 's/^.*\s+([^ ]+)$/\1/')
         if [[ -n "$sock" && -S $sock ]]; then DBSOCKET="$sock"; DBHOST=""; fi
     else
         DBSOCKET="$(/usr/bin/awk -F'=' '/^DBSocket/{ print $2 }' "${ZBX_CONFIG}")"


### PR DESCRIPTION
The previous code enumerates lists both listening and connected sockets. The output of listening (-l) is enough for the intended purpose. Optimizing this.

Further on, it matches on the first socket which in my case was mysqlx.sock which leads later to a protocol error. More specific search string resolves this.

As on this situation:
# netstat -axn | grep mysql
unix  2      [ ACC ]     STREAM     LISTENING     1934165  /var/run/mysqld/mysqlx.sock
unix  2      [ ACC ]     STREAM     LISTENING     1934169  /var/run/mysqld/mysqld.sock
unix  3      [ ]         STREAM     CONNECTED     1934197  /var/run/mysqld/mysqld.sock
[...]

we had 
# netstat -axn | grep -m1 mysq
unix  2      [ ACC ]     STREAM     LISTENING     1934165  /var/run/mysqld/mysqlx.sock

and error
ERROR 2007 (HY000): Protocol mismatch; server version = 11, client version = 10

After the fix it finds the right socket:
# netstat -lxn | grep -m1 mysqld.sock
unix  2      [ ACC ]     STREAM     LISTENING     1934169  /var/run/mysqld/mysqld.sock