### PR TITLE
Need to dump both routines, and any event(s) that trigger those routi…

### DIFF
--- a/zabbix-dump
+++ b/zabbix-dump
@@ -505,7 +505,7 @@ mkdir -p "${DUMPDIR}"
 case $DBTYPE in
     mysql)
         # dump schemas
-        DUMP_OPTS=(--opt --single-transaction --skip-lock-tables --no-data --routines)
+        DUMP_OPTS=(--opt --single-transaction --skip-lock-tables --no-data --routines --events)
         if [ $HANDLE_UNKNOWN == "ignore" ]; then
             while read -r table; do
                 if elementIn "$table" "${UNKNOWN_TABLES[@]}"; then


### PR DESCRIPTION
It is not sufficient to export just the routines.  You also need to export any events that are used to trigger those routines.  This is especially key for those of us that have partitioned our history tables, as the routines are how we maintain the partitions.

This has been tested to work for both export and import on Zabbix 3.0.31 release.  As this is a function of the mysqldump command, I would expect this to work just fine with any other Zabbix version.