### PR TITLE
Do not read neither the system-wide psqlrc file nor the user's ~/.psqlrc file

### DIFF
--- a/zabbix-dump
+++ b/zabbix-dump
@@ -326,7 +326,7 @@ case $DBTYPE in
            echo "$DBHOST:$DBPORT:$DBNAME:$DBUSER:$DBPASS" > $PGPASSFILE
            chmod 600 $PGPASSFILE
         fi
-        DB_OPTS_BATCH=("${DB_OPTS[@]}" -Atw)
+        DB_OPTS_BATCH=("${DB_OPTS[@]}" -AtwX)
         [ -n "$DBNAME" ] && DB_OPTS_BATCH=("${DB_OPTS_BATCH[@]}" -d $DBNAME)
         ;;
 esac


### PR DESCRIPTION
During [unknown tables](https://github.com/maxhq/zabbix-backup/blob/master/zabbix-dump#L455) check there is error:

`Reading database options from /etc/zabbix/zabbix_server.conf...`
`Configuration:`
` - type:     psql`
` - host:     127.0.0.1 (127.0.0.1)`
` - port:     5432`
` - database: zabbix`
` - user:     zabbix`
` - output:   /tmp/tmp.tzM4s7yilr`
`Fetching list of existing tables...`

`ERROR`
`Unknown tables found in database:`
` - Time:`
` - 7.813`
` - ms`
`To include them (full data backup) specify -f, to ignore them use -i`

It happens because I use `\timing` in `~/.psqlrc`  to see how long each query takes.

Adding `--no-psqlrc` solves the issue.

PS: System info: `postgres-server-11` on `debian-8 (jessie)`
PPS: Sorry my `Markdown` skill is poor.
